### PR TITLE
[sanand13] Add benchmarks

### DIFF
--- a/benchmarks/const-prop-after-inlining.lisp
+++ b/benchmarks/const-prop-after-inlining.lisp
@@ -1,0 +1,13 @@
+(define (f x)
+  (+ x x))
+
+(define (g x)
+  (zero? x))
+
+(print (if (g 5) (f 5)
+           (if (g 4) (f 4)
+               (if (g 3) (f 3)
+                   (if (g 2) (f 2)
+                       (if (g 1) (f 1)
+                           (if (g 0) (f 0)
+                               -1)))))))

--- a/benchmarks/cse-unnecessary-computation.lisp
+++ b/benchmarks/cse-unnecessary-computation.lisp
@@ -1,0 +1,11 @@
+(define (summation n)
+  (if (= n 0)
+      0
+      (+ n (summation (sub1 n)))))
+
+(print (- (let ((x (summation 5)))
+            (+ (let ((y (summation 5))) 1)
+               (let ((z (summation 5))) 2)))
+          (let ((x (summation 5)))
+            (+ (let ((y (summation 5))) 3)
+               (let ((z (summation 5))) 4)))))

--- a/benchmarks/inline-dag-of-functions.lisp
+++ b/benchmarks/inline-dag-of-functions.lisp
@@ -1,0 +1,13 @@
+(define (root x y)
+  (+ (left-child x) (right-child y)))
+
+(define (left-child x)
+  (+ x (left-child-child x)))
+
+(define (left-child-child x)
+  (- x (right-child x)))
+
+(define (right-child x)
+  (sub1 x))
+
+(print (root 1 2))


### PR DESCRIPTION
* `const-prop-after-inlining.lisp` only benefits from constant propagation when it gets run after inlining.
* `cse-unnecessary-computation.lisp` has a relatively expensive summation computation that runs into multiple branches of the program, and the results never happen to be used, so CSE or laziness should help.
* `inline-dag-of-functions.lisp` necessitates a specific order of inlining (starting from leaf nodes) because the function calls form a DAG.